### PR TITLE
add nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+if ! has nix_direnv_version || ! nix_direnv_version 2.2.1; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.1/direnvrc" "sha256-zelF0vLbEl5uaqrfIzbgNzJWGmLzCmYAkInj/LNxvKs="
+fi
+use flake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,23 +26,41 @@ jobs:
           name: balls
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
-      - name: build (x64)
+      - if: ${{ github.event_name == 'push' }}
+        name: build and cache (x64)
         run: |
           cachix watch-exec balls -- nix-build -A static.x86_64-linux.kpkg
-          sudo ./result/bin/kpkg
+
+      - if: ${{ github.event_name == 'pull_request' }}
+        name: build (x64)
+        run: |
+          nix-build -A static.x86_64-linux.kpkg
+
       - uses: actions/upload-artifact@v3
         with:
           name: kpkg-x64-linux
           path: ${{ github.workspace }}/result/bin/*
 
-      - name: build (aarch64)
+      - name: generate kpkg config
+        run: |
+          sudo ./result/bin/kpkg
+
+      - if: ${{ github.event_name == 'push' }}
+        name: build and cache (aarch64)
         run: |
           cachix watch-exec balls -- nix-build -A arm.static.kpkg
+
+      - if: ${{ github.event_name == 'pull_request' }}
+        name: build (aarch64)
+        run: |
+          nix-build -A arm.static.kpkg
+
       - uses: actions/upload-artifact@v3
         with:
           name: kpkg-aarch64-linux
           path: ${{ github.workspace }}/result/bin/*
 
-      - run: |
-          cachix watch-exec balls -- nix-build -A packages.x86_64-linux.purr
+      - name: test
+        run: |
+          nix-build -A packages.x86_64-linux.purr
           sudo ./result/bin/purr

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v20
-      - run: |
-          nix build .#kpkg
+
+      - name: build (x64)
+        run: |
+          nix build .#static.kpkg
           sudo ./result/bin/kpkg
       - uses: actions/upload-artifact@v3
         with:
-          name: kpkg
+          name: kpkg-x64-linux
+          path: ${{ github.workspace }}/result/bin/*
+
+      - name: build (aarch64)
+        run: |
+          nix build .#arm.kpkg
+      - uses: actions/upload-artifact@v3
+        with:
+          name: kpkg-x64-linux
           path: ${{ github.workspace }}/result/bin/*
 
       - run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: build (x64)
         run: |
-          nix build .#static.kpkg
+          nix build .#kpkg
           sudo ./result/bin/kpkg
       - uses: actions/upload-artifact@v3
         with:
@@ -36,7 +36,7 @@ jobs:
           nix build .#arm.kpkg
       - uses: actions/upload-artifact@v3
         with:
-          name: kpkg-x64-linux
+          name: kpkg-aarch64-linux
           path: ${{ github.workspace }}/result/bin/*
 
       - run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v20
+      - uses: cachix/cachix-action@v12
+        with:
+          name: balls
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: build (x64)
         run: |
-          nix build .#kpkg
+          nix build .#static.x86_64-linux.kpkg
           sudo ./result/bin/kpkg
       - uses: actions/upload-artifact@v3
         with:
@@ -33,7 +37,7 @@ jobs:
 
       - name: build (aarch64)
         run: |
-          nix build .#arm.kpkg
+          nix build .#arm.static.kpkg
       - uses: actions/upload-artifact@v3
         with:
           name: kpkg-aarch64-linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the "master" branch
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -20,17 +20,15 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v3
-      - uses: jiro4989/setup-nim-action@v1
-        with:
-          nim-version: 'stable' # default is 'stable'
-      - run: make deps
-      - run: make kpkg
+      - uses: cachix/install-nix-action@v20
+      - run: |
+          nix build .#kpkg
+          sudo ./result/bin/kpkg
       - uses: actions/upload-artifact@v3
         with:
-          name: kpkg 
-          path: ${{ github.workspace }}/out/*
-        
+          name: kpkg
+          path: ${{ github.workspace }}/result/bin/*
+
       - run: |
-          make purr
-          sudo ./out/kpkg # This is done to generate the config, purr cant seem to generate them by itself for now
-          sudo ./out/purr
+          nix build .#purr
+          sudo ./result/bin/purr

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,5 +62,5 @@ jobs:
 
       - name: test
         run: |
-          nix-build -A packages.x86_64-linux.purr
+          nix-build -A static.x86_64-linux.purr
           sudo ./result/bin/purr

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: build (x64)
         run: |
-          nix build .#static.x86_64-linux.kpkg
+          cachix watch-exec balls -- nix-build -A static.x86_64-linux.kpkg
           sudo ./result/bin/kpkg
       - uses: actions/upload-artifact@v3
         with:
@@ -37,12 +37,12 @@ jobs:
 
       - name: build (aarch64)
         run: |
-          nix build .#arm.static.kpkg
+          cachix watch-exec balls -- nix-build -A arm.static.kpkg
       - uses: actions/upload-artifact@v3
         with:
           name: kpkg-aarch64-linux
           path: ${{ github.workspace }}/result/bin/*
 
       - run: |
-          nix build .#purr
+          cachix watch-exec balls -- nix-build -A packages.x86_64-linux.purr
           sudo ./result/bin/purr

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
 packages
 src/kreastrap/kreastrap
+.direnv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 out
 packages
 src/kreastrap/kreastrap
+result
 .direnv/

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,14 @@
+(
+  import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+        sha256 = lock.nodes.flake-compat.locked.narHash;
+      }
+  )
+  {src = ./.;}
+)
+.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1676991263,
+        "narHash": "sha256-MXTZ2WdiYJ4LmWUo9Yc3DzrWr+V3NSxNE0t2ynoqYZ0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f7475ce8950b761d80a13f3f81d2c23fce60c1dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,21 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nimble": {
       "inputs": {
         "nixpkgs": "nixpkgs"
@@ -67,6 +82,7 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
         "nimble": "nimble",
         "nixpkgs": "nixpkgs_2"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "nimble": {
       "inputs": {
         "nixpkgs": "nixpkgs"
@@ -50,6 +66,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "nimble": "nimble",
         "nixpkgs": "nixpkgs_2"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,27 +1,44 @@
 {
   "nodes": {
-    "flake-utils": {
+    "nimble": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "lastModified": 1677029805,
+        "narHash": "sha256-YBmKN4107xvQIQL+cdD/n5+v6dDDK3WNBW7mbwdM7KU=",
+        "owner": "nix-community",
+        "repo": "flake-nimble",
+        "rev": "494963452cd661e713c7940b201c736aefa5a29a",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "nix-community",
+        "repo": "flake-nimble",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676991263,
-        "narHash": "sha256-MXTZ2WdiYJ4LmWUo9Yc3DzrWr+V3NSxNE0t2ynoqYZ0=",
+        "lastModified": 1641555862,
+        "narHash": "sha256-AJK1Q5djPXs/ba3K6gHsVAer9yDPVLic78ZIDsFSkHU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d1acd89e0116ff88eba80541027429fc922612e9",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1677021523,
+        "narHash": "sha256-0EhZjJ3rq8ZTTJ6Trrf/9hYtnIry0OsyY2NKoQoOS5Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f7475ce8950b761d80a13f3f81d2c23fce60c1dd",
+        "rev": "5a5adc2ad7009851d7d0fc26311e42a93b171d2e",
         "type": "github"
       },
       "original": {
@@ -33,8 +50,8 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nimble": "nimble",
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,16 +1,136 @@
 {
   description = "A basic flake with a shell";
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-      in
-      {
-        devShells.default = pkgs.mkShell {
-          packages = with pkgs; [ gnumake nim ];
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.nimble.url = "github:nix-community/flake-nimble";
+
+  outputs = {
+    self,
+    nixpkgs,
+    nimble,
+  }: let
+    lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
+    version = builtins.substring 0 8 lastModifiedDate;
+    supportedSystems = ["x86_64-linux"];
+    forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    nixpkgsFor = forAllSystems (system:
+      import nixpkgs {
+        inherit system;
+        overlays = [nimble.overlay];
+      });
+    nimBuild = "nim c -d:release -d:branch-master --threads:on -d:ssl --nimcache:.cache/";
+  in {
+    packages =
+      forAllSystems
+      (system: let
+        pkgs = nixpkgsFor.${system};
+      in rec {
+        kpkg = pkgs.stdenv.mkDerivation rec {
+          pname = "kpkg";
+          inherit version;
+
+          src = ./.;
+          nativeBuildInputs = with pkgs; with pkgs.nimPackages; [nim cligen libsha];
+
+          buildPhase = ''
+            ${nimBuild} -p:${pkgs.nimPackages.cligen} -p:${pkgs.nimPackages.libsha} -o=./out/${pname} ./src/${pname}/${pname}.nim
+          '';
+
+          installPhase = ''
+            mkdir -p $out/bin
+            cp out/${pname} $out/bin/
+          '';
+        };
+        chkupd = pkgs.stdenv.mkDerivation rec {
+          pname = "chkupd";
+          inherit version;
+
+          src = ./.;
+          nativeBuildInputs = with pkgs; with pkgs.nimPackages; [nim cligen libsha];
+
+          buildPhase = ''
+            ${nimBuild} -p:${pkgs.nimPackages.cligen} -p:${pkgs.nimPackages.libsha} -o=./out/${pname} ./src/${pname}/${pname}.nim
+          '';
+
+          installPhase = ''
+            mkdir -p $out/bin
+            cp out/${pname} $out/bin/
+          '';
+        };
+        mari = pkgs.stdenv.mkDerivation rec {
+          pname = "mari";
+          inherit version;
+
+          src = ./.;
+          nativeBuildInputs = with pkgs; with pkgs.nimPackages; [nim httpbeast libsha];
+
+          buildPhase = ''
+            ${nimBuild} -o=./out/${pname} ./src/${pname}/${pname}.nim
+          '';
+
+          installPhase = ''
+            mkdir -p $out/bin
+            cp out/${pname} $out/bin/
+          '';
+        };
+        purr = pkgs.stdenv.mkDerivation rec {
+          pname = "purr";
+          inherit version;
+
+          src = ./.;
+
+          buildInputs = [kpkg];
+          nativeBuildInputs = with pkgs; with pkgs.nimPackages; [nim cligen] ++ buildInputs;
+
+          buildPhase = ''
+            ${nimBuild} -p:${pkgs.nimPackages.libsha} -p:${pkgs.nimPackages.cligen} -o=./out/${pname} ./src/${pname}/${pname}.nim
+          '';
+
+          installPhase = ''
+            mkdir -p $out/bin
+            cp out/${pname} $out/bin
+          '';
+        };
+        kreastrap = pkgs.stdenv.mkDerivation rec {
+          pname = "kreastrap";
+          inherit version;
+
+          src = ./.;
+
+          buildInputs = [purr];
+          nativeBuildInputs = with pkgs; [nim] ++ buildInputs;
+
+          buildPhase = ''
+            ${nimBuild} -p:${pkgs.nimPackages.cligen} -p:${pkgs.nimPackages.libsha} -o=./out/${pname} ./src/${pname}/${pname}.nim
+          '';
+
+          installPhase = ''
+            mkdir -p $out/bin
+            cp out/${pname} $out/bin
+          '';
         };
       });
+
+    defaultPackage = forAllSystems (system: self.packages.${system}.kpkg);
+
+    devShell = forAllSystems (system: let
+      pkgs = nixpkgsFor.${system};
+    in
+      with pkgs;
+      with pkgs.nimPackages;
+        mkShell {
+          packages = [gnumake nim cligen libsha];
+        });
+
+    meta = with nixpkgs.lib; {
+      homepage = "https://github.com/kreatolinux/src";
+      description = "Kreato Linux source tree";
+      longDescription = ''
+        The toolset with everything you need to build, test, and maintain Kreato Linux
+      '';
+      platforms = platforms.linux;
+      license = licenses.gpl3Only;
+      maintainers = with maintainers; [kreato getchoo];
+    };
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -17,103 +17,98 @@
     lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
     version = builtins.substring 0 8 lastModifiedDate;
     supportedSystems = ["x86_64-linux"];
+
     forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
     nixpkgsFor = forAllSystems (system:
       import nixpkgs {
         inherit system;
         overlays = [nimble.overlay];
       });
-    nimBuild = "nim c -d:release -d:branch-master --threads:on -d:ssl --nimcache:.cache/";
   in {
     packages =
       forAllSystems
       (system: let
         pkgs = nixpkgsFor.${system};
-      in rec {
-        kpkg = pkgs.stdenv.mkDerivation rec {
-          pname = "kpkg";
-          inherit version;
 
-          src = ./.;
-          nativeBuildInputs = with pkgs; with pkgs.nimPackages; [nim cligen libsha];
+        libArgs = {name}: "-p:${pkgs.nimPackages.${name}}";
 
-          buildPhase = ''
-            ${nimBuild} -p:${pkgs.nimPackages.cligen} -p:${pkgs.nimPackages.libsha} -o=./out/${pname} ./src/${pname}/${pname}.nim
-          '';
+        nimBuild = {
+          name,
+          nativeBuild ? [],
+          buildInputs ? [],
+          args ? "",
+        }: {
+          ${name} = with pkgs;
+            stdenv.mkDerivation rec {
+              pname = name;
+              inherit buildInputs version;
 
-          installPhase = ''
-            mkdir -p $out/bin
-            cp out/${pname} $out/bin/
-          '';
+              src = ./.;
+              nativeBuildInputs = [nim] ++ nativeBuild;
+
+              buildPhase = ''
+                nim compile -d:release -d:branch-master --threads:on -d:ssl --nimcache:.cache/ \
+                  ${args} \
+                  -o=./out/${pname} ./src/${pname}/${pname}.nim
+              '';
+
+              installPhase = ''
+                mkdir -p $out/bin
+                cp out/${pname} $out/bin/
+              '';
+            };
         };
-        chkupd = pkgs.stdenv.mkDerivation rec {
-          pname = "chkupd";
-          inherit version;
 
-          src = ./.;
-          nativeBuildInputs = with pkgs; with pkgs.nimPackages; [nim cligen libsha];
-
-          buildPhase = ''
-            ${nimBuild} -p:${pkgs.nimPackages.cligen} -p:${pkgs.nimPackages.libsha} -o=./out/${pname} ./src/${pname}/${pname}.nim
-          '';
-
-          installPhase = ''
-            mkdir -p $out/bin
-            cp out/${pname} $out/bin/
-          '';
+        cligenArgs = libArgs {
+          name = "cligen";
         };
-        mari = pkgs.stdenv.mkDerivation rec {
-          pname = "mari";
-          inherit version;
-
-          src = ./.;
-          nativeBuildInputs = with pkgs; with pkgs.nimPackages; [nim httpbeast libsha];
-
-          buildPhase = ''
-            ${nimBuild} -o=./out/${pname} ./src/${pname}/${pname}.nim
-          '';
-
-          installPhase = ''
-            mkdir -p $out/bin
-            cp out/${pname} $out/bin/
-          '';
+        httpbeastArgs = libArgs {
+          name = "httpbeast";
         };
-        purr = pkgs.stdenv.mkDerivation rec {
-          pname = "purr";
-          inherit version;
-
-          src = ./.;
-
-          buildInputs = [kpkg];
-          nativeBuildInputs = with pkgs; with pkgs.nimPackages; [nim cligen] ++ buildInputs;
-
-          buildPhase = ''
-            ${nimBuild} -p:${pkgs.nimPackages.libsha} -p:${pkgs.nimPackages.cligen} -o=./out/${pname} ./src/${pname}/${pname}.nim
-          '';
-
-          installPhase = ''
-            mkdir -p $out/bin
-            cp out/${pname} $out/bin
-          '';
+        libshaArgs = libArgs {
+          name = "libsha";
         };
-        kreastrap = pkgs.stdenv.mkDerivation rec {
-          pname = "kreastrap";
-          inherit version;
+      in
+        with pkgs;
+          (nimBuild {
+            name = "kpkg";
+            nativeBuild = with nimPackages; [cligen libsha];
+            args = "${cligenArgs} ${libshaArgs}";
+          })
+          // (nimBuild {
+            name = "chkupd";
+            nativeBuild = with nimPackages; [cligen libsha];
+            args = "${cligenArgs} ${libshaArgs}";
+          })
+          // (nimBuild {
+            name = "mari";
+            nativeBuild = with nimPackages; [httpbeast libsha];
+            args = "${httpbeastArgs} ${libshaArgs}";
+          })
+          // (nimBuild {
+            name = "purr";
+            nativeBuild = with nimPackages; [cligen];
+            args = cligenArgs;
+            buildInputs = [self.packages.${system}.kpkg];
+          })
+          // (nimBuild {
+            name = "kreastrap";
+            buildInputs = [self.packages.${system}.purr];
+            nativeBuild = buildInputs;
+          }));
 
-          src = ./.;
-
-          buildInputs = [purr];
-          nativeBuildInputs = with pkgs; [nim] ++ buildInputs;
-
-          buildPhase = ''
-            ${nimBuild} -p:${pkgs.nimPackages.cligen} -p:${pkgs.nimPackages.libsha} -o=./out/${pname} ./src/${pname}/${pname}.nim
+    checks = forAllSystems (system: let
+      pkgs = nixpkgsFor.${system};
+    in
+      with pkgs; {
+        nimpretty =
+          runCommand "nimpretty" {
+            buildInputs = [nim];
+          }
+          ''
+            mkdir $out
+            find ${./src} -type f -name '*.nim' | xargs nimpretty
           '';
-
-          installPhase = ''
-            mkdir -p $out/bin
-            cp out/${pname} $out/bin
-          '';
-        };
       });
 
     defaultPackage = forAllSystems (system: self.packages.${system}.kpkg);
@@ -122,20 +117,8 @@
       pkgs = nixpkgsFor.${system};
     in
       with pkgs;
-      with pkgs.nimPackages;
         mkShell {
-          packages = [gnumake nim cligen libsha];
+          packages = with nimPackages; [gnumake nim cligen libsha];
         });
-
-    meta = with nixpkgs.lib; {
-      homepage = "https://github.com/kreatolinux/src";
-      description = "Kreato Linux source tree";
-      longDescription = ''
-        The toolset with everything you need to build, test, and maintain Kreato Linux
-      '';
-      platforms = platforms.linux;
-      license = licenses.gpl3Only;
-      maintainers = with maintainers; [kreato getchoo];
-    };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -3,11 +3,16 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.nimble.url = "github:nix-community/flake-nimble";
+  inputs.flake-compat = {
+    url = "github:edolstra/flake-compat";
+    flake = false;
+  };
 
   outputs = {
     self,
     nixpkgs,
     nimble,
+    flake-compat,
   }: let
     lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
     version = builtins.substring 0 8 lastModifiedDate;

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,16 @@
+{
+  description = "A basic flake with a shell";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [ gnumake nim ];
+        };
+      });
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -72,7 +72,12 @@
 
     # ------------------------------------------------------------------------------------------------
 
-    isStatic = pkgs.attr.dontDisableStatic;
+    isStatic = let
+      inherit (pkgs) attr;
+    in
+      if hasAttr "dontDisableStatic" attr
+      then attr.dontDisableStatic
+      else false;
 
     # collect and flatten args from attrsets in
     # our generated buildDeps

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -63,7 +63,7 @@
     name,
     version ? inputs.version,
     nativeBuildInputs ? [],
-    propagatedBuildInputs ? [],
+    propagatedBuildInputs ? [pkgs.openssl],
   }: let
     # ------------------------------------------------------------------------------------------------
     inherit (builtins) catAttrs concatStringsSep hasAttr;
@@ -122,6 +122,7 @@ in rec {
   kpkg = nimBuild {
     name = "kpkg";
     nativeBuildInputs = with buildDeps; [cligen libsha];
+    propagatedBuildInputs = with pkgs; [libarchive shadow openssl git];
   };
 
   # ------------------------------------------------------------------------------------------------

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,123 @@
+{
+  pkgs,
+  version,
+  ...
+} @ inputs: let
+  newDep = name: {
+    ${name} = {
+      buildArgs = ''-p:${pkgs.nimPackages.${name}}'';
+      deps = pkgs.nimPackages.${name};
+    };
+  };
+
+  buildDeps =
+    newDep "cligen"
+    // newDep "libsha"
+    # // newDep "httpbeast"
+    # TODO: remove this if asynctools is ever bumped in flake-nimble
+    # https://github.com/nix-community/flake-nimble/issues/17
+    // (let
+      inherit (pkgs.nimPackages) nim;
+
+      httpbeast = pkgs.nimPackages.httpbeast.overrideAttrs (_: let
+        asynctools = pkgs.nimPackages.asynctools.overrideAttrs (_: let
+          # using the latest commit as of 2023-03-24
+          # this should be somewhat ok for the long term
+          # as the project hasn't been updated in a while
+          rev = "84ced6d002789567f2396c75800ffd6dff2866f7";
+        in {
+          version = builtins.substring 0 8 rev;
+          src = pkgs.fetchFromGitHub {
+            owner = "cheatfate";
+            repo = "asynctools";
+            inherit rev;
+            sha256 = "sha256-mrO+WeSzCBclqC2UNCY+IIv7Gs8EdTDaTeSgXy3TgNM=";
+          };
+        });
+      in {
+        propagatedBuildInputs = [asynctools nim];
+        doCheck = false; # the test suite tries to touch $HOME...no.
+      });
+    in {
+      httpbeast = {
+        buildArgs = ''-p:${httpbeast}/src'';
+        deps = httpbeast;
+      };
+    });
+
+  nimBuild = {
+    name,
+    version ? inputs.version,
+    nativeBuildInputs ? [],
+    propagatedBuildInputs ? [],
+  }: let
+    inherit (builtins) catAttrs concatStringsSep hasAttr;
+    inherit (pkgs) nim stdenv;
+    inherit (pkgs.lib) flatten;
+
+    # collect and flatten args from attrsets in buildDeps
+    # that are being used
+    buildArgs = concatStringsSep " " (flatten (catAttrs "buildArgs" nativeBuildInputs));
+
+    # ditto but with their deps
+    nat = map (dep:
+      if hasAttr "deps" dep
+      then dep.deps
+      else dep)
+    nativeBuildInputs;
+  in
+    stdenv.mkDerivation rec {
+      pname = name;
+      inherit version propagatedBuildInputs;
+
+      src = ../.;
+
+      nativeBuildInputs = [nim] ++ nat;
+
+      buildPhase = ''
+        nim compile -d:release -d:branch-master --threads:on -d:ssl --nimcache:$TMPDIR \
+          ${buildArgs} \
+          -o=./out/${pname} ./src/${pname}/${pname}.nim
+      '';
+
+      installPhase = ''
+        mkdir -p $out/bin
+        cp out/${pname} $out/bin/
+      '';
+    };
+in rec {
+  kpkg = nimBuild {
+    name = "kpkg";
+    nativeBuildInputs = with buildDeps; [cligen libsha];
+  };
+
+  chkupd = nimBuild {
+    name = "chkupd";
+    nativeBuildInputs = with buildDeps; [cligen libsha];
+  };
+
+  mari = nimBuild {
+    name = "mari";
+    nativeBuildInputs = with buildDeps; [httpbeast libsha];
+  };
+
+  purr = nimBuild {
+    name = "purr";
+    nativeBuildInputs = with buildDeps; [cligen libsha];
+    propagatedBuildInputs = [kpkg];
+  };
+
+  kreastrap = nimBuild rec {
+    name = "kreastrap";
+    nativeBuildInputs = with buildDeps; [cligen libsha];
+    propagatedBuildInputs = [purr];
+  };
+
+  # dummy package to build everything at once
+  all =
+    pkgs.runCommand "build-all" {
+      buildInputs = [kpkg chkupd mari purr kreastrap];
+    } ''
+      mkdir $out
+    '';
+}

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,0 +1,64 @@
+# ------------------------------------------------------------------------------------------------
+# declare packages
+# ------------------------------------------------------------------------------------------------
+{
+  buildDeps,
+  isStatic,
+  nimBuild,
+  pkgs,
+}: rec {
+  # ------------------------------------------------------------------------------------------------
+  kpkg = nimBuild {
+    name = "kpkg";
+    nativeBuildInputs = with buildDeps; [cligen libsha];
+    propagatedBuildInputs = let
+      git = pkgs.git.override {doInstallCheck = false;};
+    in
+      (with pkgs; [libarchive shadow openssl])
+      ++ (
+        if isStatic
+        then [git]
+        else [pkgs.git]
+      );
+  };
+
+  # ------------------------------------------------------------------------------------------------
+
+  chkupd = nimBuild {
+    name = "chkupd";
+    nativeBuildInputs = with buildDeps; [cligen libsha];
+  };
+
+  # ------------------------------------------------------------------------------------------------
+
+  mari = nimBuild {
+    name = "mari";
+    nativeBuildInputs = with buildDeps; [httpbeast libsha];
+  };
+
+  # ------------------------------------------------------------------------------------------------
+
+  purr = nimBuild {
+    name = "purr";
+    nativeBuildInputs = with buildDeps; [cligen libsha];
+    propagatedBuildInputs = [kpkg];
+  };
+
+  # ------------------------------------------------------------------------------------------------
+
+  kreastrap = nimBuild rec {
+    name = "kreastrap";
+    nativeBuildInputs = with buildDeps; [cligen libsha];
+    propagatedBuildInputs = [purr];
+  };
+
+  # ------------------------------------------------------------------------------------------------
+
+  # dummy package to build everything at once
+  all =
+    pkgs.runCommand "build-all" {
+      buildInputs = [kpkg chkupd mari purr kreastrap];
+    } ''
+      mkdir $out
+    '';
+}

--- a/src/kpkg/info.nim
+++ b/src/kpkg/info.nim
@@ -1,4 +1,4 @@
-proc info(package: seq[string]): string =
+proc info(package: seq[string], testing = false): string =
     ## Get information about packages
 
     if package.len == 0:
@@ -22,5 +22,11 @@ proc info(package: seq[string]): string =
         echo "package epoch: "&pkg.epoch
     if dirExists("/var/cache/kpkg/installed/"&pkg.pkg):
         return "installed: yes"
+
+    # don't error when package isn't installed during testing
+    const ret = "installed: no"
+    if testing:
+      return ret
+
     # return err if package isn't installed (for scripting :p)
-    err("installed: no", false)
+    err(ret, false)

--- a/src/kpkg/info.nim
+++ b/src/kpkg/info.nim
@@ -26,7 +26,7 @@ proc info(package: seq[string], testing = false): string =
     # don't error when package isn't installed during testing
     const ret = "installed: no"
     if testing:
-      return ret
+        return ret
 
     # return err if package isn't installed (for scripting :p)
     err(ret, false)

--- a/src/purr/purr.nim
+++ b/src/purr/purr.nim
@@ -24,7 +24,7 @@ proc purr(tests = "all", tmpdir = "/tmp/purr") =
     # TODO: remove repo from config when successful
     discard update("https://github.com/kreatolinux/purr-test-repo.git", "/tmp/purr/test")
     if dirExists(tmpdir&"/test"):
-        ok("update test completed succesfully")
+        ok("update test completed successfully")
     else:
         error("update test failed")
 
@@ -39,7 +39,7 @@ proc purr(tests = "all", tmpdir = "/tmp/purr") =
     #discard remove(packages = toSeq(["purr"]), yes = true,
     #        root = "/tmp/purr/root")
     #if not fileExists(tmpdir&"root/testfile"):
-    #    ok("remove test completed succesfully")
+    #    ok("remove test completed successfully")
     #else:
     #    error("remove test failed")
 
@@ -48,7 +48,7 @@ proc purr(tests = "all", tmpdir = "/tmp/purr") =
     else:
         ok("dephandler test completed successfully")
 
-    discard info(toSeq(["purr"]))
+    discard info(toSeq(["purr"]), true)
     ok("info test completed")
 
     # Test install_bin (and the functions it uses)


### PR DESCRIPTION
so this does a few swag things

### devshell
this lets you use nix while not breaking your workflow, and also giving people an easier way to start contributing. you can install [nix-direnv](https://github.com/nix-community/nix-direnv), cd into the repository, and make and nim (or whatever else we use in the future) will be there ready for you to use

### packaging everything in nix 
this isn't really about people using nix to install kpkg and other tools, but moreso using it as a development tool. by having our builds controlled by nix, we can get a lot of flexibility and easy, cool features to mess with

### ez cross compliation
speaking of cool features we can mess with, cross compiling all tools in this repository is now really easy! currently, only x64 -> aarch64 is supported -- but with a lot of the infrastructure nix already has, this can easily be scaled up to other architectures like ppc64le, i386, risc-v, maybe even mips and android. all it takes is one command: `nix build .#<architecture>.<package>`

### static builds
yes...these are a work in progress and a part of the reason this is a draft. static builds can be compiled for all architectures and when cross compiling, but they don't work due to an issue with libcrypt.so. if it's possible to fix, this would be a great way to provide users with the opportunity to easily test in-development builds of the tools, or even just as a recovery option in case their installation gets messed up

### compatibility with legacy nix tools
tools like `nix-build` and `nix-shell` will still work with this flake, for those who aren't interested in flakes and aren't enabled. everything is automated and "just works" so we don't really have to worry about upkeep, it just makes things easier for others

### workflow changes
build.yml is the first workflow to start using nix, where building, distributing, and testing can all take place with only the nix command (reproducibly ofc). this doesn't really make any changes, to the way it works, it only gives us the ability to work in the same environment as the ci (so no more "why is it working on my machine but not in ci???" issues :trollface:)

it'd be cool imo to expand this nix integration to other workflows and maybe even the builder container image...but i want feedback before i go further down the deep end
<br></br>
oh and almost forgot: if you merge, this badge can go in the readme so it's instantly cool<br>
![built with nix](https://raw.githubusercontent.com/nix-community/builtwithnix.org/master/badge.svg)